### PR TITLE
Allow the action to run against any commit SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Migrations are tested by running them against an empty, ephemeral database insta
 | Name            | Description                                                                           | Default          | Required |
 | --------------- | ------------------------------------------------------------------------------------- | ---------------- | -------- |
 | projectId       | The id of the project number to test                                                  | N/A              | Yes      |
-| ref             | The github ref against which tests should run                                         | N/A              | Yes      |
 
 ## Outputs
 
@@ -25,7 +24,6 @@ steps:
     uses: red-gate/flyway-hub-migration-test@v1
     with:
       projectId: 1
-      ref: ${{ github.ref }}
 ```
 
 ## Authentication

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,6 @@ inputs:
   projectId:
     description: 'The id of the Flyway Hub project to test'
     required: true
-  ref:
-    description: 'The github ref against which tests should run'
-    required: true
 
 outputs: {}
 
@@ -18,4 +15,3 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.projectId }}
-    - ${{ inputs.ref }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,6 @@
 hubhost="https://app-flyway-spawn.staging.spawn.cc"
 
 projectId=$1
-ref=$(echo "$2" | cut -f3 -d'/')
 
 if [[ -z "$FLYWAY_HUB_ACCESS_TOKEN" ]]; then
     echo "FLYWAY_HUB_ACCESS_TOKEN is not set"
@@ -16,7 +15,7 @@ headers=$(https --ignore-stdin --check-status --headers \
   $hubhost/api/test-migrations \
   "Authorization: Bearer $FLYWAY_HUB_ACCESS_TOKEN" \
   projectId:=$projectId \
-  branch="$ref")
+  hash="$GITHUB_SHA")
 
 locationHeader=$(echo "$headers" | grep 'Location: ')
 if [ -z "$locationHeader" ]; then


### PR DESCRIPTION
Don't take a ref as an argument, run against `$GITHUB_SHA` instead.

`$GITHUB_SHA `is provided as an env var to all workflow runs and contains the hash of the commit that triggered the run.

`POST` the `SHA` to the API endpoint now that it is able to receive them.