### PR TITLE
Display results of migration test in output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/httpie:2.6.0
 
-RUN apk update && apk add jq
+RUN apk update && apk add jq util-linux
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,6 @@ while true ; do
     "Authorization: Bearer $FLYWAY_HUB_ACCESS_TOKEN")
 
   status=$(echo $result | jq -r '.status')
-  echo "migration test status: $status"
 
   if [ "$status" = "COMPLETED" ]
   then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,8 @@ while true ; do
 
   if [ "$status" = "COMPLETED" ]
   then
+    echo "Status: $(echo $result | jq --raw-output '.status')"
+    echo
     echo $result | jq --raw-output \
       '["CATEGORY", "VERSION", "PATH", "DURATION"], (.flyway_output | fromjson.migrations[] | [(.category, .version, .filepath, "\(.executionTime)ms")]) | @tsv' \
       | column -t

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,8 +60,8 @@ while true ; do
   fi
 done
 
-echo ""
+echo
 echo "test output available on Flyway Hub at: $hubhost/project/$projectId/job/$jobId"
-echo ""
+echo
 
 exit $exitCode

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,9 @@ while true ; do
 
   if [ "$status" = "COMPLETED" ]
   then
+    echo $result | jq --raw-output \
+      '(["Category", "Version", "Path", "Duration"] | (., map(length*"-"))), (.flyway_output | fromjson.migrations[] | [(.category, .version, .filepath, "\(.executionTime)ms")]) | @tsv' \
+      | column -t
     exitCode=0
     break
   elif [ "$status" = "FAILED" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ while true ; do
   if [ "$status" = "COMPLETED" ]
   then
     echo $result | jq --raw-output \
-      '(["Category", "Version", "Path", "Duration"] | (., map(length*"-"))), (.flyway_output | fromjson.migrations[] | [(.category, .version, .filepath, "\(.executionTime)ms")]) | @tsv' \
+      '["CATEGORY", "VERSION", "PATH", "DURATION"], (.flyway_output | fromjson.migrations[] | [(.category, .version, .filepath, "\(.executionTime)ms")]) | @tsv' \
       | column -t
     exitCode=0
     break

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ while true ; do
 done
 
 echo
-echo "test output available on Flyway Hub at: $hubhost/project/$projectId/job/$jobId"
+echo "Full test output available on Flyway Hub at: $hubhost/project/$projectId/job/$jobId"
 echo
 
 exit $exitCode


### PR DESCRIPTION
Display the results of the migration test in the action output, in addition to linking back to Flyway Hub:

*Successful run*:
![image](https://user-images.githubusercontent.com/8225907/142429114-bd09a52d-b325-4d3a-84d9-fbbee2d92f75.png)

*Failed run*:
![image](https://user-images.githubusercontent.com/8225907/142437896-9fc21088-af6c-42d1-923a-ca8103a6c4fc.png)
