### PR TITLE
Support database name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Migrations are tested by running them against an empty, ephemeral database insta
 | --------------- | ------------------------------------------------------------------------------------- | ---------------- | -------- |
 | projectId       | The id of the project number to test                                                  | N/A              | Yes      |
 | flywayConfPath  | The path to the flyway conf to use when running this migration test                   | N/A              | No       |
+| databaseName    | The custom database to create and run the flyway migrations against                   | N/A              | No       |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   flywayConfPath:
     description: 'The path to the flyway conf to use when running this migration test'
     required: false
+  databaseName:
+    description: 'The custom database to create and run the flyway migrations against'
+    required: false
+
 
 outputs: {}
 
@@ -19,3 +23,4 @@ runs:
   args:
     - ${{ inputs.projectId }}
     - ${{ inputs.flywayConfPath }}
+    - ${{ inputs.databaseName }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,11 +11,18 @@ hubhost="https://hub.flywaydb.org"
 
 projectId=$1
 flywayConfPath=$2
+databaseName=$3
 
 if [ -z "$flywayConfPath" ]; then
   flywayConfPath=null
 else
   flywayConfPath=\"$flywayConfPath\"
+fi
+
+if [ -z "$databaseName" ]; then
+  databaseName=null
+else
+  databaseName=\"$databaseName\"
 fi
 
 if [[ -z "$FLYWAY_HUB_ACCESS_TOKEN" ]]; then
@@ -39,6 +46,7 @@ headers=$(https --ignore-stdin --check-status --headers \
   "Authorization: Bearer $FLYWAY_HUB_ACCESS_TOKEN" \
   projectId:=$projectId \
   flywayConf:=$flywayConfPath \
+  database_name:=$databaseName \
   $payload)
 
 locationHeader=$(echo "$headers" | grep 'Location: ')


### PR DESCRIPTION
Allows users to provide a custom database name for Flyway Hub to run the create and then run the migration test against.