### PR TITLE
Install `jq` into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM public.ecr.aws/j7l4v0f3/flywayhub:d7bc96f23ebccf84ecbcc8db667969670f19360d
 
-COPY entrypoint.sh /entrypoint.sh
-
 USER root
+
+RUN apt-get update && apt-get install -y jq
+
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The action was failing against pull request triggers because we forgot to install `jq` into the image.

We use `jq` to pull the PR number of the github event data when running triggered by a PR.