### PR TITLE
Bump `flywayhub` version and use the new `--initiator` argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j7l4v0f3/flywayhub:d7bc96f23ebccf84ecbcc8db667969670f19360d
+FROM public.ecr.aws/j7l4v0f3/flywayhub:58bb022e707b407c0214f316efea853c30ee6ed7
 
 USER root
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,7 @@ fi
 flywayhub --verbose test \
   --project $projectName \
   --engine "$engine" \
+  --initiator "Github Actions" \
   $flywayConfPathFlag \
   $databaseFlag \
   $prNumberFlag \


### PR DESCRIPTION
Bump the version of the `flywayhub` base image to the latest available. This means:

* We can use the new `--initiator` flag so that workflow runs show in the Flyway Hub UI as having been run from Actions:

![image](https://user-images.githubusercontent.com/8225907/148090010-f49ff980-a750-4fa0-ae73-050578e8430f.png)

* The updated `flywayhub` image fails with non-zero exit code correctly, so action runs fail as expected on migration failures:

![image](https://user-images.githubusercontent.com/8225907/148090325-f6006c4f-2ba4-49df-a4c5-f69c27715590.png)
