### PR TITLE
Use the public docker hub repository for the action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j7l4v0f3/flywayhub:58bb022e707b407c0214f316efea853c30ee6ed7
+FROM flyway/flywayhub:0.5.0
 
 USER root
 


### PR DESCRIPTION
Moves to using the now publicly-available-on-docker-hub image for the Flyway Hub CLI.